### PR TITLE
Specify that any game can be picked as long as it hasn’t started yet

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
 
     <h3>Weekly deadlines</h3>
 
-    <p>All picks must be entered by the start of the 1PM games on Sunday <em>unless</em> you are picking one of the teams playing on Thursday night. When picking one of the teams playing on Thursday, you are required to enter your picks for that game only before the game begins.</p>
+    <p>Once a game has started it can no longer be picked, e.g. you must enter a Thursday night pick on Thursday but can wait until Sunday to enter the rest. If you didn’t enter any picks on Sunday, you can still pick one (or both) of the teams playing on Monday. At the end of the week, any invalid picks (e.g. picking a team who you were not eligible to pick that week) or picks that were left unmade will be automatically chosen for you, without mercy (the best team(s) who happened to lose that week).</p>
 
-    <p>If you're unable to enter your picks in the spreadsheet by the weekly deadline, make sure you send your picks via email to others in the group before the deadline, to ensure that there's a (digital) paper trail. But really you should be able to enter them on time, considering that you probably have a smartphone and that the Google mobile apps work just fine in a pinch.</p>
+    <p>If you're unable to enter your picks in the spreadsheet, make sure you send your picks via email to others in the group before the deadline, to ensure that there's a (digital) paper trail. But really you should be able to enter them on time, considering that you probably have a smartphone and that the Google mobile apps work just fine in a pinch.</p>
 
     <h3>Rules specific to week 17</h3>
 


### PR DESCRIPTION
Previously, we said that all (non-Thursday) picks _had_ to be entered by 1PM Sunday.
